### PR TITLE
readme, license and small fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SploonMC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# bin-patch-gen 
+
+**bin-patch-gen** is a tool designed to generate binary patches for all Minecraft versions supported by Spigot.
+
+## Usage
+
+### Manual Usage
+
+#### Default Mode
+```bash
+./bin-patch-gen
+```
+This runs the program in its default mode. It retrieves a list of all versions that Spigot's BuildTools can build, iterates through them, and builds each version. After building, it generates a `bsdiff`/`bspatch` compatible patch file that can convert a vanilla server jar into a Spigot server jar.
+
+#### Specific Version
+```bash
+./bin-patch-gen --version x.xx.x
+```
+This runs the program to generate a binary patch for a specific Minecraft version. Replace `x.xx.x` with the desired version.  
+For example:  
+```bash
+./bin-patch-gen --version 1.21.3
+```
+Generates a patch for version 1.21.3.
+
+#### Patch Mode
+```bash
+./bin-patch-gen patch oldfile newfile patchfile
+```
+This mode applies a patch to transform one file into another.  
+- `oldfile`: The original file to be patched.  
+- `patchfile`: The binary patch file.  
+- `newfile`: The output file resulting from applying the patch.  
+
+### Docker
+Insert documentation here.
+
+## Building
+To build this project, you need Cargo and a recent version of Rust from the nightly channel. Building is straightforward, like any other Rust program:
+```bash
+cargo build
+```
+
+## Contributing
+Insert documentation here.
+
+## License
+Insert documentation here.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ For example:
 ```
 Generates a patch for version 1.21.3.
 
+#### Force Mode
+```bash
+./bin-patch-gen --force
+```
+Builds all versions regardless of whether they have already been built.
+
+#### Clean Mode
+```bash
+./bin-patch-gen --clean
+```
+Removes all contents of the `run` directory. If the current working directory is named `run`, it will be cleared. This ensures a clean environment before starting the process.
+
+**Note**: This may result in the deletion of important files, so use this option with caution.
+
 #### Patch Mode
 ```bash
 ./bin-patch-gen patch oldfile newfile patchfile

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # bin-patch-gen 
 
-**bin-patch-gen** is a tool designed to generate binary patches for all Minecraft versions supported by Spigot.
+**bin-patch-gen** is a tool designed to generate SpigotMC binary patches for all SpigotMC-supported Minecraft versions.
 
 ## Usage
-
-### Manual Usage
 
 #### Default Mode
 ```bash
@@ -47,7 +45,8 @@ This mode applies a patch to transform one file into another.
 - `newfile`: The output file resulting from applying the patch.  
 
 ### Docker
-Insert documentation here.
+There is a provided `docker-compose.yml` file which you can use. Our CI runs a cronjob with the provided `update.sh` script, which
+just runs the docker container and pushes the patches to Git.
 
 ## Building
 To build this project, you need Cargo and a recent version of Rust from the nightly channel. Building is straightforward, like any other Rust program:
@@ -56,7 +55,14 @@ cargo build
 ```
 
 ## Contributing
-Insert documentation here.
+Any pull requests and issues are welcome.
+
+All contributions should be:
+- made to the dev branch.
+- formatted using rustfmt.
+- tested.
+
+CI Contributions should only be done by maintainers.
 
 ## License
-Insert documentation here.
+This project is licensed under the MIT license.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use bin_patch_gen::jar::extract_jar;
 use bin_patch_gen::util::dir::create_temp_dir;
 use bin_patch_gen::util::{sha1, TimeFormatter};
 use bin_patch_gen::version::{fetch_spigot_version_meta, fetch_versions};
-use bin_patch_gen::{config, jar, prepare_extraction_path, write_patch, MinecraftVersion, JAR_VERSIONS_PATH, MINECRAFT_VERSION_REGEX, SPIGOT_SERVER_JAR_REGEX};
+use bin_patch_gen::{config, jar, prepare_extraction_path, write_patch, MinecraftVersion, JAR_VERSIONS_PATH, SPIGOT_SERVER_JAR_REGEX};
 use clap::{command, Parser, Subcommand};
 use qbsdiff::Bspatch;
 use regex::Regex;
@@ -133,7 +133,6 @@ async fn run(versions: Vec<String>, run_dir: PathBuf, force_build: bool) -> Resu
     info!("Downloaded BuildTools successfully!");
 
     let vanilla_jar_regex = Regex::new(VANILLA_JAR_REGEX)?;
-    let minecraft_version_regex = Regex::new(MINECRAFT_VERSION_REGEX)?;
     let spigot_jar_regex = Regex::new(SPIGOT_SERVER_JAR_REGEX)?;
 
     if !run_dir.exists() {
@@ -145,7 +144,6 @@ async fn run(versions: Vec<String>, run_dir: PathBuf, force_build: bool) -> Resu
         let version_path = temp_dir.join(Path::new(&*version));
         let work_path = version_path.join(Path::new("work"));
         let vanilla_jar_regex = vanilla_jar_regex.clone();
-        let minecraft_version_regex = minecraft_version_regex.clone();
         let spigot_jar_regex = spigot_jar_regex.clone();
 
         let mc_version = MinecraftVersion::of(version.clone());
@@ -211,7 +209,7 @@ async fn run(versions: Vec<String>, run_dir: PathBuf, force_build: bool) -> Resu
             } else {
                 let file_content = file_content.unwrap();
                 let split_content = file_content
-                    .split("    ")
+                    .split("\t")
                     .collect::<Vec<&str>>();
 
                 let jar_path_relative = split_content


### PR DESCRIPTION
- adds readme
- licenses under MIT
- fixes the tab character being converted to 4 spaces, using `\t` instead