### PR TITLE
remove SpigotVersionMeta::tools_version

### DIFF
--- a/src/version/schema/spigot.rs
+++ b/src/version/schema/spigot.rs
@@ -5,7 +5,6 @@ pub struct SpigotVersionMeta {
     pub name: String,
     pub description: String,
     pub refs: SpigotVersionRefs,
-    pub tools_version: u16,
 }
 
 #[serial_pascal]


### PR DESCRIPTION
it doesn't exist in older versions, and we're never actually using it