### PR TITLE
fix: not rebuilding for new spigot builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY . .
 
 RUN cargo install --path .
 
-CMD ["bin_patch_gen", "-v", "1.21.3"]
+CMD ["bin_patch_gen"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY . .
 
 RUN cargo install --path .
 
-CMD ["bin_patch_gen"]
+CMD ["bin_patch_gen", "-v", "1.21.3"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ./config.toml:/app/config.toml
       - ./work:/app/run
+      - /tmp/bpg:/tmp/bin-patch-gen
     mem_limit: 2G
   tests:
     container_name: sploon-bin-patch-gen-tests
@@ -13,4 +14,5 @@ services:
     volumes:
       - ./config.toml:/app/config.toml
       - ./work:/app/run
+      - /tmp/bpg:/tmp/bin-patch-gen
     mem_limit: 2G

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub async fn run(
                 warn!("{version} metadata is invalid or could not be read! Rebuilding...");
             } else {
                 let patched_meta = patched_meta.unwrap();
-                if remote_meta.refs == patched_meta.commit_hashes && !force_build && library_file.exists() {
+                if remote_meta.refs_eq(patched_meta.commit_hashes) && !force_build && library_file.exists() {
                     info!("Already built version {version}, skipping");
                     continue;
                 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -29,19 +29,3 @@ pub fn sha1<P: AsRef<Path>>(path: P) -> io::Result<String> {
 
     Ok(hex::encode(hasher.finalize()))
 }
-
-pub trait StringOptionExt<T> {
-    fn equals(&self, other: T) -> bool;
-}
-
-impl StringOptionExt<String> for Option<String> {
-    fn equals(&self, other: String) -> bool {
-        if self.is_none() {
-            return false;
-        }
-        
-        let string = self.clone().unwrap();
-        
-        string == other
-    }
-}

--- a/src/version/schema/spigot.rs
+++ b/src/version/schema/spigot.rs
@@ -7,15 +7,26 @@ pub struct SpigotVersionMeta {
     pub refs: SpigotVersionRefs,
 }
 
+impl SpigotVersionMeta {
+    pub fn refs_eq(&self, other: SpigotVersionRefs) -> bool {
+        let refs = self.refs.clone();
+
+        refs.build_data == other.build_data
+            && refs.bukkit == other.bukkit
+            && refs.craft_bukkit == other.craft_bukkit
+            && refs.spigot == other.spigot
+    }
+}
+
 #[serial_pascal]
 pub struct SpigotVersionRefs {
     pub build_data: String,
     pub bukkit: String,
     pub craft_bukkit: String,
-    pub spigot: String
+    pub spigot: String,
 }
 
 #[serial]
 pub struct SpigotBuildData {
-    pub server_url: String
+    pub server_url: String,
 }


### PR DESCRIPTION
This should make BPG rebuild for each new Spigot Build because Eq was wrong or something, not sure

This is gonna eat up my CI server's CPU frfr